### PR TITLE
Add greenback.bestow_portal()

### DIFF
--- a/docs/source/principle.rst
+++ b/docs/source/principle.rst
@@ -19,8 +19,8 @@ implementation detail of the particular framework you're using. For
 example, asyncio yields `~asyncio.Future`\s, curio yields specially
 formatted tuples, and Trio (currently) yields internal objects
 representing the two primitive operations
-:func:`~trio.hazmat.cancel_shielded_checkpoint` and
-:func:`~trio.hazmat.wait_task_rescheduled`.  For much more detail on
+:func:`~trio.lowlevel.cancel_shielded_checkpoint` and
+:func:`~trio.lowlevel.wait_task_rescheduled`.  For much more detail on
 how ``async``/``await`` work (more approachably explained, too!), see
 the excellent writeup by Brett Cannon: `How the heck does async/await
 work in Python 3.5?
@@ -119,7 +119,7 @@ loop and get their responses sent back down.
 
 Once you understand the approach, most of the remaining trickery is in
 the answer to the question: "how do we install this shim coroutine?"
-In Trio you can directly replace `trio.hazmat.Task.coro` with a
+In Trio you can directly replace `trio.lowlevel.Task.coro` with a
 wrapper of your choosing, but in asyncio the ability to modify the
 analogous field is not exposed publicly, and on CPython it's not even
 exposed to Python at all. It's necessary to use `ctypes` to edit the

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -11,6 +11,11 @@ In order to use `greenback` in a particular async task, you must first call
 
 .. autofunction:: ensure_portal
 
+To support debugging and introspection tools, it's also possible to
+enable `greenback` in a task from outside that task:
+
+.. autofunction:: bestow_portal
+
 Once the portal has been set up, you can use it with :func:`await_`:
 
 .. autofunction:: await_(awaitable)

--- a/greenback/__init__.py
+++ b/greenback/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for greenback."""
 
 from ._version import __version__
-from ._impl import ensure_portal, await_
+from ._impl import ensure_portal, bestow_portal, await_
 from ._util import autoawait, async_context, async_iter

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -96,7 +96,7 @@ def current_task() -> Union["trio.lowlevel.Task", "asyncio.Task[Any]"]:
     if library == "trio":
         try:
             from trio.lowlevel import current_task
-        except ImportError:
+        except ImportError:  # pragma: no cover
             if not TYPE_CHECKING:
                 from trio.hazmat import current_task
 
@@ -193,7 +193,7 @@ def bestow_portal(task: Union["trio.lowlevel.Task", "asyncio.Task[Any]"]) -> Non
     if type(task).__module__.startswith("trio."):
         try:
             from trio.lowlevel import Task
-        except ImportError:
+        except ImportError:  # pragma: no cover
             if not TYPE_CHECKING:
                 from trio.hazmat import Task
 

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -97,7 +97,8 @@ def current_task() -> Union["trio.lowlevel.Task", "asyncio.Task[Any]"]:
         try:
             from trio.lowlevel import current_task
         except ImportError:
-            from trio.hazmat import current_task
+            if not TYPE_CHECKING:
+                from trio.hazmat import current_task
 
         return current_task()
     elif library == "asyncio":
@@ -193,7 +194,8 @@ def bestow_portal(task: Union["trio.lowlevel.Task", "asyncio.Task[Any]"]) -> Non
         try:
             from trio.lowlevel import Task
         except ImportError:
-            from trio.hazmat import Task
+            if not TYPE_CHECKING:
+                from trio.hazmat import Task
 
         assert isinstance(task, Task)
         shim_coro = greenback_shim(task.coro)
@@ -249,7 +251,7 @@ async def ensure_portal() -> None:
     # This is necessary in case the caller immediately invokes greenback.await_()
     # without any further checkpoints.
     library = sniffio.current_async_library()
-    await sys.modules[library].sleep(0)
+    await sys.modules[library].sleep(0)  # type: ignore
 
 
 async def adapt_awaitable(aw: Awaitable[T]) -> T:

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -91,6 +91,7 @@ async def test_bestow(library):
         await tg.spawn(task_fn)
         await task_started.wait()
         greenback.bestow_portal(task)
+        greenback.bestow_portal(task)
         await portal_installed.set()
 
     with pytest.raises(RuntimeError):

--- a/newsfragments/1.feature.rst
+++ b/newsfragments/1.feature.rst
@@ -2,4 +2,4 @@ Added :func:`greenback.bestow_portal`, which enables greenback for a task from o
 of that task.
 
 Added support for newer versions of Trio with a `trio.lowlevel` module rather than
-`trio.hazmat`.
+``trio.hazmat``.

--- a/newsfragments/1.feature.rst
+++ b/newsfragments/1.feature.rst
@@ -1,0 +1,5 @@
+Added :func:`greenback.bestow_portal`, which enables greenback for a task from outside
+of that task.
+
+Added support for newer versions of Trio with a `trio.lowlevel` module rather than
+`trio.hazmat`.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,14 +4,14 @@ pytest-cov
 pytest-trio
 
 # We run tests on both asyncio and Trio
-trio
+trio >= 0.16.0
 anyio
 
 # Tools
 black == 19.10b0; implementation_name == "cpython"
 mypy >= 0.750; implementation_name == "cpython"
 flake8
-trio-typing
+trio-typing >= 0.5.0
 
 # typed-ast is required by black + mypy and doesn't build on PyPy;
 # it will be unconstrained in requirements.txt if we don't


### PR DESCRIPTION
For use in debuggers and such where you need to make a task greenback-able without running code within it.

Also update to support trio.lowlevel as the new name for trio.hazmat. (greenback still works on older Trio versions that use hazmat.)