### PR TITLE
Update anyio version used in tests

### DIFF
--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -1,7 +1,7 @@
 import collections
 import greenlet  # type: ignore
 import outcome
-import sniffio  # type: ignore
+import sniffio
 import sys
 import types
 import weakref

--- a/greenback/_tests/conftest.py
+++ b/greenback/_tests/conftest.py
@@ -1,6 +1,6 @@
 import importlib
 import inspect
-import pytest  # type: ignore
+import pytest
 from functools import partial
 
 # Tests declared with a "library" parameter will run twice, once under asyncio

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -15,10 +15,6 @@ import greenback
 from .._impl import ensure_portal, bestow_portal, await_
 
 
-async def noop():
-    pass
-
-
 async def test_simple(library):
     ticks = 0
 

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -19,12 +19,6 @@ async def noop():
     pass
 
 
-with warnings.catch_warnings():
-    # anyio hasn't been updated for the deprecations in Trio 0.15.0 yet
-    warnings.simplefilter("ignore")
-    anyio.run(noop, backend="trio")
-
-
 async def test_simple(library):
     ticks = 0
 
@@ -53,25 +47,25 @@ async def test_simple(library):
 
 
 async def test_complex(library):
-    server = await anyio.create_tcp_server()
+    listener = await anyio.create_tcp_listener(local_host="0.0.0.0")
 
     async def serve_echo_client(conn):  # pragma: no cover
         await ensure_portal()
-        for chunk in greenback.async_iter(conn.receive_chunks(1024)):
-            await_(conn.send_all(chunk))
+        for chunk in greenback.async_iter(conn):
+            await_(conn.send(chunk))
 
     async def serve_echo():  # pragma: no cover
         await ensure_portal()
         with greenback.async_context(anyio.create_task_group()) as tg:
-            for conn in greenback.async_iter(server.accept_connections()):
-                await_(tg.spawn(serve_echo_client, conn))
+            await_(listener.serve(serve_echo_client, tg))
 
     async with anyio.create_task_group() as tg:
         await tg.spawn(serve_echo)
         await ensure_portal()
-        conn = await_(anyio.connect_tcp("127.0.0.1", server.port))
-        await_(conn.send_all(b"hello"))
-        assert b"hello" == await_(conn.receive_some(1024))
+        port = listener.extra(anyio.abc.SocketAttribute.local_port)
+        conn = await_(anyio.connect_tcp("127.0.0.1", port))
+        await_(conn.send(b"hello"))
+        assert b"hello" == await_(conn.receive(1024))
         await_(tg.cancel_scope.cancel())
 
 

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -6,8 +6,8 @@ import sys
 import warnings
 
 import anyio
-import pytest  # type: ignore
-import sniffio  # type: ignore
+import pytest
+import sniffio
 import trio
 import trio.testing
 

--- a/greenback/_tests/test_util.py
+++ b/greenback/_tests/test_util.py
@@ -1,5 +1,5 @@
 import gc
-import pytest  # type: ignore
+import pytest
 import trio
 from async_generator import asynccontextmanager
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["greenlet", "sniffio", "outcome",],
-    keywords=["async", "io", "trio", "asyncio",],
+    install_requires=["greenlet!=0.4.17", "sniffio", "outcome"],
+    keywords=["async", "io", "trio", "asyncio"],
     python_requires=">=3.6",
     classifiers=[
         "License :: OSI Approved :: MIT License",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ pytest-trio
 
 # We run tests on both asyncio and Trio
 trio >= 0.16.0
-anyio
+anyio >= 2.0
 
 # Tools
 black == 19.10b0; implementation_name == "cpython"


### PR DESCRIPTION
Pin greenlet below the new 0.4.17 version with the contextvars bug for now. Workaround coming in a later PR.