### PR TITLE
Update CI: test on 3.9, 3.9-dev, and nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   Windows:
@@ -14,12 +18,13 @@ jobs:
           - '3.6'
           - '3.7'
           - '3.8'
+          - '3.9.0-rc.2'
         arch: ['x86', 'x64']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '${{ matrix.python }}'
           architecture: '${{ matrix.arch }}'
@@ -41,6 +46,7 @@ jobs:
           - '3.6'
           - '3.7'
           - '3.8'
+          - '3.9.0-rc.2'
         check_docs: ['0']
         check_lint: ['0']
         extra_name: ['']
@@ -55,7 +61,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '${{ matrix.python }}'
       - name: Run tests
@@ -77,11 +83,12 @@ jobs:
           - '3.6'
           - '3.7'
           - '3.8'
+          - '3.9.0-rc.2'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '${{ matrix.python }}'
       - name: Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ matrix:
     - python: 3.6-dev
     - python: 3.7-dev
     - python: 3.8-dev
-    # Disabling nightly until greenlet makes a release that includes
-    # https://github.com/python-greenlet/greenlet/pull/161
-    #- python: nightly
+    - python: 3.9-dev
+    - python: nightly
 
 script:
   - ./ci.sh


### PR DESCRIPTION
Don't run tests twice when pushing branches to origin.