### PR TITLE
Work around greenlet 0.4.17's misguided contextvars support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,17 @@ jobs:
           - '3.8'
           - '3.9.0-rc.2'
         arch: ['x86', 'x64']
+        extra_name: ['']
+        old_greenlet: ['0']
+        include:
+          - python: '3.7'
+            arch: 'x86'
+            old_greenlet: '1'
+            extra_name: ', older greenlet package'
+          - python: '3.9.0-rc.2'
+            arch: 'x64'
+            old_greenlet: '1'
+            extra_name: ', older greenlet package'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,8 +43,9 @@ jobs:
         run: ./ci.sh
         shell: bash
         env:
+          OLD_GREENLET: '${{ matrix.old_greenlet }}'
           # Should match 'name:' up above
-          JOB_NAME: 'Windows (${{ matrix.python }}, ${{ matrix.arch }})'
+          JOB_NAME: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
 
   Linux:
     name: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
@@ -50,6 +62,7 @@ jobs:
         check_docs: ['0']
         check_lint: ['0']
         extra_name: ['']
+        old_greenlet: ['0']
         include:
           - python: '3.8'
             check_docs: '1'
@@ -57,6 +70,12 @@ jobs:
           - python: '3.8'
             check_lint: '1'
             extra_name: ', formatting and linting'
+          - python: '3.7'
+            old_greenlet: '1'
+            extra_name: ', older greenlet package'
+          - python: '3.9.0-rc.2'
+            old_greenlet: '1'
+            extra_name: ', older greenlet package'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -69,6 +88,7 @@ jobs:
         env:
           CHECK_DOCS: '${{ matrix.check_docs }}'
           CHECK_LINT: '${{ matrix.check_lint }}'
+          OLD_GREENLET: '${{ matrix.old_greenlet }}'
           # Should match 'name:' up above
           JOB_NAME: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ script:
   - ./ci.sh
 
 branches:
-  except:
-    - /^dependabot/.*/
+  only:
+    - master
+

--- a/ci.sh
+++ b/ci.sh
@@ -146,7 +146,12 @@ else
 
     INSTALLDIR=$(python -c "import os, greenback; print(os.path.dirname(greenback.__file__))")
     cp ../setup.cfg $INSTALLDIR
-    if pytest -W error -ra --junitxml=../test-results.xml ${INSTALLDIR} --cov="$INSTALLDIR" --cov-config=../.coveragerc$pypy_tag --verbose; then
+    # We have to copy .coveragerc into this directory, rather than passing
+    # --cov-config=../.coveragerc to pytest, because codecov.sh will run
+    # 'coverage xml' to generate the report that it uses, and that will only
+    # apply the ignore patterns in the current directory's .coveragerc.
+    cp ../.coveragerc$pypy_tag .coveragerc
+    if pytest -W error -ra --junitxml=../test-results.xml ${INSTALLDIR} --cov="$INSTALLDIR" --verbose; then
         PASSED=true
     else
         PASSED=false

--- a/ci.sh
+++ b/ci.sh
@@ -135,6 +135,12 @@ else
     # Actual tests
     python -m pip install -r test-requirements.txt
 
+    if [ "$OLD_GREENLET" = "1" ]; then
+        # We run some tests under a greenlet version without the contextvars bug,
+        # to make sure we haven't regressed that
+        python -m pip install greenlet==0.4.16
+    fi
+
     mkdir empty
     cd empty
 

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -25,7 +25,10 @@ if TYPE_CHECKING:
 
 try:
     import contextvars
-except ImportError:
+except ImportError:  # pragma: no cover
+    # 'no cover' rationale: Trio pulls in the contextvars backport,
+    # and it's not worth adding more CI runs in environments that
+    # specifically exclude Trio.
     if not TYPE_CHECKING:
         contextvars = None
 

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -259,7 +259,7 @@ def set_greenlet_context(
 
     # See comments in set_aio_task_coro().
     import ctypes
-    import _ctypes  # type: ignore
+    import _ctypes
 
     context_field = ctypes.c_size_t.from_address(id(gr) + greenlet_context_c_offset)
     assert context_field.value == (0 if old_context is None else id(old_context))

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
     import trio
     import asyncio
 
+try:
+    import contextvars
+except ImportError:
+    if not TYPE_CHECKING:
+        contextvars = None
+
 T = TypeVar("T")
 
 # Maps each task (trio.lowlevel.Task or asyncio.Task) that has called
@@ -37,6 +43,20 @@ task_portal: MutableMapping[object, greenlet.greenlet] = weakref.WeakKeyDictiona
 # asyncio.Task is implemented in C (which it generally is on CPython 3.6+).
 # This is determined dynamically when it is first needed.
 aio_task_coro_c_offset: Optional[int] = None
+
+# If True, we're using a buggy version of greenlet which will clobber our
+# contextvars context when we switch greenlets.
+# See https://github.com/python-greenlet/greenlet/issues/196 for details.
+greenlet_needs_context_fixup: bool = (
+    sys.implementation.name == "cpython"
+    and contextvars is not None
+    and getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
+)
+
+# The offset of greenlet.context in the greenlet object memory layout.
+# Only relevant if greenlet_needs_context_fixup.
+# This is determined dynamically when it is first needed.
+greenlet_context_c_offset: Optional[int] = None
 
 
 async def greenback_shim(orig_coro: Coroutine[Any, Any, Any]) -> Any:
@@ -75,11 +95,14 @@ def _greenback_shim(orig_coro: Coroutine[Any, Any, Any]) -> Generator[Any, Any, 
             if not child_greenlet:
                 # Start a new send() or throw() call on the original coroutine.
                 child_greenlet = greenlet.greenlet(next_send.send)
-                next_yield = child_greenlet.switch(orig_coro)
+                switch_arg: Any = orig_coro
             else:
                 # Resume the previous send() or throw() call, which is currently
                 # at a simulated yield point in a greenback.await_() call.
-                next_yield = child_greenlet.switch(next_send)
+                switch_arg = next_send
+            if greenlet_needs_context_fixup:
+                fix_greenlet_context(child_greenlet)
+            next_yield = child_greenlet.switch(switch_arg)
             if child_greenlet.dead:
                 # The send() or throw() call completed so we need to
                 # create a new greenlet for the next one.
@@ -124,6 +147,22 @@ def get_aio_task_coro(task: "asyncio.Task[Any]") -> Coroutine[Any, Any, Any]:
         return task._coro  # type: ignore  # (not in typeshed)
 
 
+def _aligned_ptr_offset_in_object(obj: object, referent: object) -> Optional[int]:
+    """Return the byte offset in the C representation of *obj* (an
+    arbitrary Python object) at which is found a naturally-aligned
+    pointer that points to *referent*.  If *search_for*
+    can't be found, return None.
+    """
+    import ctypes
+
+    size = obj.__sizeof__()
+    arraytype = ctypes.c_size_t * (size // ctypes.sizeof(ctypes.c_size_t))
+    for idx, value in enumerate(arraytype.from_address(id(obj))):
+        if value == id(referent):
+            return idx * ctypes.sizeof(ctypes.c_size_t)
+    return None
+
+
 def set_aio_task_coro(
     task: "asyncio.Task[Any]", new_coro: Coroutine[Any, Any, Any]
 ) -> None:
@@ -148,13 +187,8 @@ def set_aio_task_coro(
     if aio_task_coro_c_offset is None:
         # Deduce the offset by scanning the task object representation
         # for id(task._coro)
-        size = task.__sizeof__()
-        arraytype = ctypes.c_size_t * (size // ctypes.sizeof(ctypes.c_size_t))
-        for idx, value in enumerate(arraytype.from_address(id(task))):
-            if value == id(old_coro):
-                aio_task_coro_c_offset = idx * ctypes.sizeof(ctypes.c_size_t)
-                break
-        else:  # pragma: no cover
+        aio_task_coro_c_offset = _aligned_ptr_offset_in_object(task, old_coro)
+        if aio_task_coro_c_offset is None:  # pragma: no cover
             raise RuntimeError("Couldn't determine C offset of asyncio.Task._coro")
 
     # (Explanation copied from trio._core._multierror, applies equally well here.)
@@ -170,6 +204,78 @@ def set_aio_task_coro(
     _ctypes.Py_INCREF(new_coro)
     coro_field.value = id(new_coro)
     _ctypes.Py_DECREF(old_coro)
+
+
+def get_greenlet_context(gr: greenlet.greenlet) -> Optional["contextvars.Context"]:
+    """Return the contextvars.Context that *gr* will execute in.
+
+    The result will be None for a greenlet that is currently executing
+    or has not yet been started. Raises RuntimeError if the loaded
+    greenlet doesn't have contextvars support (includes all releases
+    before 0.4.17, which was released September 2020).
+    """
+
+    global greenlet_context_c_offset
+    import ctypes
+    import contextvars
+
+    if greenlet_context_c_offset is None:
+        ctx = contextvars.copy_context()
+        scratch_greenlet = greenlet.greenlet(ctx.run)
+        # This activates `ctx` and then switches back, saving `ctx` in the
+        # greenlet object.
+        scratch_greenlet.switch(greenlet.getcurrent().switch)
+        try:
+            greenlet_context_c_offset = _aligned_ptr_offset_in_object(
+                scratch_greenlet, ctx
+            )
+        finally:
+            # Resume the greenlet so it properly unregisters its
+            # context, else we're likely to get an exception when we
+            # exit whatever Context.run() call surrounds
+            # set_greenlet_context().
+            scratch_greenlet.switch()
+        if greenlet_context_c_offset is None:  # pragma: no cover
+            raise RuntimeError(
+                "Couldn't determine C offset of greenlet.greenlet.<context>"
+            )
+
+    context_field = ctypes.c_size_t.from_address(id(gr) + greenlet_context_c_offset)
+    if context_field.value == 0:
+        return None
+
+    # This interprets the context field as a PyObject* and creates a new
+    # Python reference to that object.
+    ctx = ctypes.cast(context_field.value, ctypes.py_object).value
+    assert isinstance(ctx, contextvars.Context)
+    return ctx
+
+
+def set_greenlet_context(
+    gr: greenlet.greenlet, new_context: "contextvars.Context"
+) -> None:
+    old_context = get_greenlet_context(gr)
+    assert greenlet_context_c_offset is not None
+
+    # See comments in set_aio_task_coro().
+    import ctypes
+    import _ctypes  # type: ignore
+
+    context_field = ctypes.c_size_t.from_address(id(gr) + greenlet_context_c_offset)
+    assert context_field.value == (0 if old_context is None else id(old_context))
+    _ctypes.Py_INCREF(new_context)
+    context_field.value = id(new_context)
+    if old_context is not None:
+        _ctypes.Py_DECREF(old_context)
+
+
+def fix_greenlet_context(gr: greenlet.greenlet) -> None:
+    # Determine the current context by storing it in the current greenlet.
+    scratch_child = greenlet.greenlet(get_greenlet_context)
+    current_context = scratch_child.switch(greenlet.getcurrent())
+
+    # Update *gr* so it will continue to use this context when we switch to it.
+    set_greenlet_context(gr, current_context)
 
 
 def bestow_portal(task: Union["trio.lowlevel.Task", "asyncio.Task[Any]"]) -> None:

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -134,6 +134,16 @@ def test_misuse():
             greenback.await_(42)
 
 
+def test_find_ptr_in_object():
+    from greenback._impl import _aligned_ptr_offset_in_object
+
+    class A:
+        pass
+
+    assert _aligned_ptr_offset_in_object(A(), A) == object().__sizeof__() / 2
+    assert _aligned_ptr_offset_in_object(A(), "nope") is None
+
+
 @types.coroutine
 def async_yield(value):
     return (yield value)

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -88,6 +88,35 @@ async def test_bestow(library):
         await_(anyio.sleep(0))
 
 
+async def test_contextvars(library):
+    if sys.version_info < (3, 7) and library != "trio":
+        pytest.skip("contextvars not supported on this version")
+
+    import contextvars
+
+    cv = contextvars.ContextVar("cv")
+
+    async def inner():
+        assert cv.get() == 20
+        await anyio.sleep(0)
+        cv.set(30)
+
+    def middle():
+        assert cv.get() == 10
+        cv.set(20)
+        await_(inner())
+        assert cv.get() == 30
+        cv.set(40)
+
+    cv.set(10)
+    await greenback.ensure_portal()
+    assert cv.get() == 10
+    middle()
+    assert cv.get() == 40
+    await anyio.sleep(0)
+    assert cv.get() == 40
+
+
 def test_misuse():
     with pytest.raises(sniffio.AsyncLibraryNotFoundError):
         greenback.await_(42)

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -134,6 +134,7 @@ def test_misuse():
             greenback.await_(42)
 
 
+@pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython only")
 def test_find_ptr_in_object():
     from greenback._impl import _aligned_ptr_offset_in_object
 

--- a/newsfragments/5.bugfix.rst
+++ b/newsfragments/5.bugfix.rst
@@ -1,0 +1,2 @@
+Work around a regression introduced by greenlet 0.4.17's attempt at adding
+contextvars support.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["greenlet!=0.4.17", "sniffio", "outcome"],
+    install_requires=["greenlet", "sniffio", "outcome"],
     keywords=["async", "io", "trio", "asyncio"],
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
greenlet 0.4.17 added support for switching contextvars when switching greenlets. Great! Except... each greenlet now starts with an empty context, and trying to work around this with `Context.run()` tends to result in problems not keeping the implicit stack of `Context.run()` calls properly nested (since if you switch away from a greenlet, any `Context.run()` it was in the middle of still appears to be active). See https://github.com/python-greenlet/greenlet/issues/196 for more details.

Work around this by using ctypes to change the new greenlet's context pointer to be the same as the old one before switching. This probably comes with some performance cost, but I don't see a better alternative.