### PR TITLE
Add support for greenlet >= 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9.0-rc.2'
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         arch: ['x86', 'x64']
         extra_name: ['']
         old_greenlet: ['0']
@@ -27,7 +23,7 @@ jobs:
             arch: 'x86'
             old_greenlet: '1'
             extra_name: ', older greenlet package'
-          - python: '3.9.0-rc.2'
+          - python: '3.10'
             arch: 'x64'
             old_greenlet: '1'
             extra_name: ', older greenlet package'
@@ -37,7 +33,15 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '${{ matrix.python }}'
+          # This allows the matrix to specify just the major.minor version while still
+          # expanding it to get the latest patch version including alpha releases.
+          # This avoids the need to update for each new alpha, beta, release candidate,
+          # and then finally an actual release version.  actions/setup-python doesn't
+          # support this for PyPy presently so we get no help there.
+          #
+          # CPython -> 3.9.0-alpha - 3.9.X
+          # PyPy    -> pypy-3.7
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python), matrix.python))[startsWith(matrix.python, 'pypy')] }}
           architecture: '${{ matrix.arch }}'
       - name: Run tests
         run: ./ci.sh
@@ -47,50 +51,59 @@ jobs:
           # Should match 'name:' up above
           JOB_NAME: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
 
-  Linux:
-    name: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
+  Ubuntu:
+    name: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9.0-rc.2'
+        python: ['pypy-3.6', 'pypy-3.7', 'pypy-3.8', '3.6', '3.7', '3.8', '3.9', '3.10', '3.8-dev', '3.9-dev', '3.10-dev']
         check_docs: ['0']
         check_lint: ['0']
         extra_name: ['']
         old_greenlet: ['0']
         include:
-          - python: '3.8'
+          - python: '3.9'
             check_docs: '1'
             extra_name: ', check docs'
-          - python: '3.8'
+          - python: '3.9'
             check_lint: '1'
             extra_name: ', formatting and linting'
           - python: '3.7'
             old_greenlet: '1'
             extra_name: ', older greenlet package'
-          - python: '3.9.0-rc.2'
+          - python: '3.10'
             old_greenlet: '1'
             extra_name: ', older greenlet package'
+          - python: '3.7'  # <- not actually used
+            pypy_nightly_branch: 'py3.7'
+            extra_name: ', pypy 3.7 nightly'
+          - python: '3.8'  # <- not actually used
+            pypy_nightly_branch: 'py3.8'
+            extra_name: ', pypy 3.8 nightly'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v2
+        if: "!endsWith(matrix.python, '-dev')"
+        with:
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python), matrix.python))[startsWith(matrix.python, 'pypy')] }}
+      - name: Setup python (dev)
+        uses: deadsnakes/action@v2.0.2
+        if: endsWith(matrix.python, '-dev')
         with:
           python-version: '${{ matrix.python }}'
       - name: Run tests
         run: ./ci.sh
         env:
+          PYPY_NIGHTLY_BRANCH: '${{ matrix.pypy_nightly_branch }}'
           CHECK_DOCS: '${{ matrix.check_docs }}'
           CHECK_LINT: '${{ matrix.check_lint }}'
           OLD_GREENLET: '${{ matrix.old_greenlet }}'
           # Should match 'name:' up above
-          JOB_NAME: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
+          JOB_NAME: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
 
   macOS:
     name: 'macOS (${{ matrix.python }})'
@@ -99,18 +112,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9.0-rc.2'
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '${{ matrix.python }}'
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python), matrix.python))[startsWith(matrix.python, 'pypy')] }}
       - name: Run tests
         run: ./ci.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             arch: 'x86'
             old_greenlet: '1'
             extra_name: ', older greenlet package'
-          - python: '3.10'
+          - python: '3.9'  # NB: old greenlet not supported on >=3.10
             arch: 'x64'
             old_greenlet: '1'
             extra_name: ', older greenlet package'
@@ -73,7 +73,7 @@ jobs:
           - python: '3.7'
             old_greenlet: '1'
             extra_name: ', older greenlet package'
-          - python: '3.10'
+          - python: '3.9'  # NB: old greenlet not supported on >=3.10
             old_greenlet: '1'
             extra_name: ', older greenlet package'
           - python: '3.7'  # <- not actually used

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -31,10 +31,10 @@ a greenback *portal* for that task to use. You may choose between:
   simpler and will be a bit faster (probably only noticeable if the
   function you're running is very short).
 
-.. autofunction:: ensure_portal
-.. autofunction:: bestow_portal
-.. autofunction:: with_portal_run
-.. autofunction:: with_portal_run_sync
+.. autofunction:: ensure_portal()
+.. autofunction:: bestow_portal(task)
+.. autofunction:: with_portal_run(async_fn, *args, **kwds)
+.. autofunction:: with_portal_run_sync(sync_fn, *args, **kwds)
 
 
 Using the portal

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -54,8 +54,7 @@ aio_task_coro_c_offset: Optional[int] = None
 # to get the behavior we want; we forbid it in our setup.py dependencies.)
 # See https://github.com/python-greenlet/greenlet/issues/196 for details.
 greenlet_needs_context_fixup: bool = (
-    contextvars is not None
-    and getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
+    contextvars is not None and getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
 )
 
 

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -54,8 +54,7 @@ aio_task_coro_c_offset: Optional[int] = None
 # to get the behavior we want; we forbid it in our setup.py dependencies.)
 # See https://github.com/python-greenlet/greenlet/issues/196 for details.
 greenlet_needs_context_fixup: bool = (
-    sys.implementation.name == "cpython"
-    and contextvars is not None
+    contextvars is not None
     and getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
 )
 
@@ -404,7 +403,7 @@ async def ensure_portal() -> None:
 
 async def with_portal_run(
     async_fn: Callable[..., Awaitable[T]], *args: Any, **kwds: Any
-) -> T:
+) -> "T":
     """Execute ``await async_fn(*args, **kwds)`` in a context that is able
     to use :func:`greenback.await_`.
 

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -403,7 +403,7 @@ async def ensure_portal() -> None:
 
 async def with_portal_run(
     async_fn: Callable[..., Awaitable[T]], *args: Any, **kwds: Any
-) -> "T":
+) -> T:
     """Execute ``await async_fn(*args, **kwds)`` in a context that is able
     to use :func:`greenback.await_`.
 

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 
 import anyio
-import greenlet
+import greenlet  # type: ignore
 import pytest
 import sniffio
 import trio
@@ -125,9 +125,8 @@ async def test_contextvars(library):
         cv.set(20)
         await_(inner())
         assert cv.get() == 30
-        if (
-            sys.version_info >= (3, 7)
-            and getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
+        if sys.version_info >= (3, 7) and getattr(
+            greenlet, "GREENLET_USE_CONTEXT_VARS", False
         ):
             # greenlet is not aware of the backported contextvars,
             # so can't support Context.run() correctly before 3.7.

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -6,6 +6,7 @@ import sys
 import warnings
 
 import anyio
+import greenlet
 import pytest
 import sniffio
 import trio
@@ -124,9 +125,14 @@ async def test_contextvars(library):
         cv.set(20)
         await_(inner())
         assert cv.get() == 30
-        if sys.version_info >= (3, 7):
+        if (
+            sys.version_info >= (3, 7)
+            and getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
+        ):
             # greenlet is not aware of the backported contextvars,
-            # so can't support Context.run() correctly before 3.7
+            # so can't support Context.run() correctly before 3.7.
+            # greenlet that isn't contextvars-aware hangs if the
+            # inner greenlet uses Context.run() -- not our fault.
             cv.set(50)
             nctx = contextvars.copy_context()
             nctx.run(cv.set, 20)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["greenlet", "sniffio", "outcome"],
+    install_requires=["greenlet != 0.4.17", "sniffio", "outcome"],
     keywords=["async", "io", "trio", "asyncio"],
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
I contributed a patch to upstream greenlet that exposes a `gr_context` attribute, so we don't have to hack-change the context using ctypes. Drop support for greenlet 0.4.17 which changes the context but doesn't make it configurable.