### PR TITLE
Add with_portal_run_tree() and has_portal()

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,6 @@ Quickstart
 
 * Later, use ``greenback.await_(foo())`` as a replacement for
   ``await foo()`` in places where you can't write ``await``.
-  `documentation <https://greenback.readthedocs.io>`__.
 
 * For more details and additional helpers, read the rest of this documentation!
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -14,9 +14,11 @@ a greenback *portal* for that task to use. You may choose between:
   code change to allow :func:`greenback.await_` in a particular task.
 
 * :func:`bestow_portal`: Create a portal to be used by some other specified task,
-  which lasts for the lifetime of that task. Use case: debugging and introspection
-  tools, such as writing a Trio instrument that makes *all* tasks (or all tasks
-  in a particular nursery) support :func:`await_` from the start.
+  which lasts for the lifetime of that task. Use case: enabling greenback in a task
+  without that task's cooperation, which may be useful in some debugging and
+  instrumentation situations. (:func:`with_portal_run_tree` is implemented
+  using a Trio instrument that calls :func:`bestow_portal` on certain newly
+  spawned tasks.)
 
 * :func:`with_portal_run`: Run an async function (in the current task)
   that might eventually make calls to :func:`await_`, with a portal
@@ -31,10 +33,23 @@ a greenback *portal* for that task to use. You may choose between:
   simpler and will be a bit faster (probably only noticeable if the
   function you're running is very short).
 
+* :func:`with_portal_run_tree`: Run an async function (in the current
+  task) that can make calls to :func:`await_` both itself and in all
+  of its child tasks, recursively.  Available on Trio only, since
+  asyncio lacks a clear task tree and also lacks the instrumentation
+  features required to implement this. Use case: minimally invasive
+  code change to allow :func:`greenback.await_` in an entire subsystem
+  of your Trio program.
+
+You can use :func:`has_portal` to determine whether a portal has already
+been set up.
+
 .. autofunction:: ensure_portal()
 .. autofunction:: bestow_portal(task)
 .. autofunction:: with_portal_run(async_fn, *args, **kwds)
 .. autofunction:: with_portal_run_sync(sync_fn, *args, **kwds)
+.. autofunction:: with_portal_run_tree(async_fn, *args, **kwds)
+.. autofunction:: has_portal(task=None)
 
 
 Using the portal

--- a/greenback/__init__.py
+++ b/greenback/__init__.py
@@ -4,8 +4,10 @@ from ._version import __version__
 from ._impl import (
     ensure_portal,
     bestow_portal,
+    has_portal,
     with_portal_run,
     with_portal_run_sync,
+    with_portal_run_tree,
     await_,
 )
 from ._util import autoawait, async_context, async_iter

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -487,7 +487,7 @@ class AutoPortalInstrument(Instrument):
         self.refs = 0
 
     def task_spawned(self, task: "trio.lowlevel.Task") -> None:
-        if task.parent_nursery is None:  # pragma: no branch
+        if task.parent_nursery is None:  # pragma: no cover
             # We shouldn't see the init task (since this instrument is
             # added only after run() starts up) but don't crash if we do.
             return

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -487,7 +487,7 @@ class AutoPortalInstrument(Instrument):
         self.refs = 0
 
     def task_spawned(self, task: "trio.lowlevel.Task") -> None:
-        if task.parent_nursery is None:
+        if task.parent_nursery is None:  # pragma: no branch
             # We shouldn't see the init task (since this instrument is
             # added only after run() starts up) but don't crash if we do.
             return

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -108,6 +108,7 @@ async def test_with_portal_run_tree():
 
     async with trio.open_nursery() as outer:
         async with trio.open_nursery() as middle:
+
             @outer.start_soon
             async def check_no_leakage():
                 await trio.sleep(0.5)

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -108,6 +108,12 @@ async def test_with_portal_run_tree():
 
     async with trio.open_nursery() as outer:
         async with trio.open_nursery() as middle:
+            @outer.start_soon
+            async def check_no_leakage():
+                await trio.sleep(0.5)
+                outer.start_soon(expect_no_portal)
+                middle.start_soon(expect_no_portal)
+
             assert not has_portal()
             outer.start_soon(expect_no_portal)
             middle.start_soon(expect_no_portal)

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -6,7 +6,6 @@ import sys
 import warnings
 
 import anyio
-import asyncio
 import greenlet  # type: ignore
 import pytest
 import sniffio
@@ -190,7 +189,7 @@ async def test_contextvars(library):
 
 def test_misuse():
     with pytest.raises(RuntimeError, match="only supported.*running under Trio"):
-        asyncio.run(greenback.with_portal_run_tree(anyio.sleep, 1))
+        anyio.run(greenback.with_portal_run_tree, anyio.sleep, 1, backend="asyncio")
 
     with pytest.raises(sniffio.AsyncLibraryNotFoundError):
         greenback.await_(42)

--- a/greenback/_util.py
+++ b/greenback/_util.py
@@ -107,30 +107,3 @@ class async_generator(async_iter[T]):
 
     def close(self) -> None:
         return await_(cast(AsyncGenerator[T, Any], self._it).aclose())
-
-
-try:
-    from trio.abc import Instrument
-    from trio.lowlevel import Task
-except ImportError:
-    Instrument = object
-    Task = Any
-
-
-class AutoPortalInstrument(Instrument):
-    """Use as a Trio instrument to make a greenback portal implicitly
-    available in every task.
-
-    Example uses::
-
-        # Start a Trio run in which every task will be able to use greenback.await_()
-        trio.run(main, instruments=[greenback.AutoPortalInstrument()])
-
-        # Make all tasks started after this point in the current Trio run
-        # able to use greenback.await_(), leaving tasks already running unaffected
-        trio.lowlevel.add_instrument(greenback.AutoPortalInstrument())
-
-    """
-
-    def task_spawned(self, task: Task) -> None:
-        bestow_portal(task)

--- a/newsfragments/8.bugfix.rst
+++ b/newsfragments/8.bugfix.rst
@@ -1,0 +1,4 @@
+Add support for newer (1.0+) versions of greenlet, which expose a ``gr_context``
+attribute directly, allowing us to remove the hacks that were added to support
+0.4.17. greenlet 0.4.17 is no longer supported, but earlier (contextvar-naive)
+versions should still work.

--- a/newsfragments/9.bugfix.rst
+++ b/newsfragments/9.bugfix.rst
@@ -1,0 +1,5 @@
+We no longer assume that :func:`greenback.bestow_portal` is invoked from the
+"main" greenlet of the event loop. This was not a safe assumption: any task
+running with access to a greenback portal runs in a separate greenlet, and
+it is quite plausible that such a task might want to :func:`~greenback.bestow_portal`
+on another task.

--- a/newsfragments/9.feature.rst
+++ b/newsfragments/9.feature.rst
@@ -1,0 +1,9 @@
+New function :func:`greenback.with_portal_run_tree` is like
+:func:`greenback.with_portal_run` for an entire Trio task subtree: it
+will enable :func:`greenback.await_` not only in the given async
+function but also in any child tasks spawned inside that
+function. This feature relies on the Trio instrumentation API and is
+thus unavailable on asyncio.
+
+New function :func:`greenback.has_portal` determines whether the current
+task, or another specified task, has a greenback portal set up already.


### PR DESCRIPTION
`with_portal_run_tree()` is like `with_portal_run()` except that it "infects" child tasks also: any task underneath it in the call tree can use `await_()`. Trio only.

`has_portal()` just queries whether a task already has a portal set up.

Fix `bestow_portal()` so it doesn't need to be run in the top-level greenlet, because that was easy to screw up (any task with a portal set up is not running in the top-level greenlet) and created extremely confusing errors (one task's traps would get delivered to another task, more or less at random).