### PR TITLE
Release v1.0.0

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,36 @@ Release history
 
 .. towncrier release notes start
 
+greenback 1.0.0 (2021-11-23)
+----------------------------
+
+Features
+~~~~~~~~
+
+- New function :func:`greenback.with_portal_run_tree` is like
+  :func:`greenback.with_portal_run` for an entire Trio task subtree: it
+  will enable :func:`greenback.await_` not only in the given async
+  function but also in any child tasks spawned inside that
+  function. This feature relies on the Trio instrumentation API and is
+  thus unavailable on asyncio. (`#9 <https://github.com/oremanj/greenback/issues/9>`__)
+- New function :func:`greenback.has_portal` determines whether the current
+  task, or another specified task, has a greenback portal set up already. (`#9 <https://github.com/oremanj/greenback/issues/9>`__)
+
+
+Bugfixes
+~~~~~~~~
+
+- Add support for newer (1.0+) versions of greenlet, which expose a ``gr_context``
+  attribute directly, allowing us to remove the hacks that were added to support
+  0.4.17. greenlet 0.4.17 is no longer supported, but earlier (contextvar-naive)
+  versions should still work. (`#8 <https://github.com/oremanj/greenback/issues/8>`__)
+- We no longer assume that :func:`greenback.bestow_portal` is invoked from the
+  "main" greenlet of the event loop. This was not a safe assumption: any task
+  running with access to a greenback portal runs in a separate greenlet, and
+  it is quite plausible that such a task might want to :func:`~greenback.bestow_portal`
+  on another task. (`#9 <https://github.com/oremanj/greenback/issues/9>`__)
+
+
 greenback 0.3.0 (2020-10-13)
 ----------------------------
 

--- a/greenback/_version.py
+++ b/greenback/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.3.0+dev"
+__version__ = "1.0.0"

--- a/greenback/_version.py
+++ b/greenback/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "1.0.0"
+__version__ = "1.0.0+dev"

--- a/newsfragments/8.bugfix.rst
+++ b/newsfragments/8.bugfix.rst
@@ -1,4 +1,0 @@
-Add support for newer (1.0+) versions of greenlet, which expose a ``gr_context``
-attribute directly, allowing us to remove the hacks that were added to support
-0.4.17. greenlet 0.4.17 is no longer supported, but earlier (contextvar-naive)
-versions should still work.

--- a/newsfragments/9.bugfix.rst
+++ b/newsfragments/9.bugfix.rst
@@ -1,5 +1,0 @@
-We no longer assume that :func:`greenback.bestow_portal` is invoked from the
-"main" greenlet of the event loop. This was not a safe assumption: any task
-running with access to a greenback portal runs in a separate greenlet, and
-it is quite plausible that such a task might want to :func:`~greenback.bestow_portal`
-on another task.

--- a/newsfragments/9.feature.rst
+++ b/newsfragments/9.feature.rst
@@ -1,9 +1,0 @@
-New function :func:`greenback.with_portal_run_tree` is like
-:func:`greenback.with_portal_run` for an entire Trio task subtree: it
-will enable :func:`greenback.await_` not only in the given async
-function but also in any child tasks spawned inside that
-function. This feature relies on the Trio instrumentation API and is
-thus unavailable on asyncio.
-
-New function :func:`greenback.has_portal` determines whether the current
-task, or another specified task, has a greenback portal set up already.


### PR DESCRIPTION
I'm going to be using this in production-ish at $DAYJOB. The new SQLAlchemy async ORM support uses basically the same technique. I think it's not a weird shot in the dark anymore, and we can call it 1.0.