### PR TITLE
Fix has_portal()

### DIFF
--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -391,7 +391,7 @@ async def ensure_portal() -> None:
     # This is necessary in case the caller immediately invokes greenback.await_()
     # without any further checkpoints.
     library = sniffio.current_async_library()
-    await sys.modules[library].sleep(0)  # type: ignore
+    await sys.modules[library].sleep(0)
 
 
 def has_portal(

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -401,7 +401,12 @@ def has_portal(
     :func:`greenback.await_`, false otherwise. If no *task* is
     specified, query the currently executing task.
     """
-    return current_task() in task_has_portal
+    if task is None:
+        try:
+            task = current_task()
+        except sniffio.AsyncLibraryNotFoundError:
+            return False
+    return task in task_has_portal
 
 
 async def with_portal_run(
@@ -561,7 +566,7 @@ async def with_portal_run_tree(
     elif this_task in instrument.tasks:
         # We're already inside another call to with_portal_run_tree(), so nothing
         # more needs to be done
-        assert has_portal()
+        assert this_task in task_has_portal
         return await async_fn(*args, **kwds)
 
     # Store our current nursery depth. This allows the instrument to

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -144,7 +144,9 @@ async def test_bestow(library):
     async with anyio.create_task_group() as tg:
         tg.start_soon(task_fn)
         await task_started.wait()
+        assert not has_portal(task)
         greenback.bestow_portal(task)
+        assert has_portal(task)
         greenback.bestow_portal(task)
         portal_installed.set()
 
@@ -195,6 +197,8 @@ async def test_contextvars(library):
 
 
 def test_misuse():
+    assert not greenback.has_portal()  # shouldn't raise an error
+
     with pytest.raises(RuntimeError, match="only supported.*running under Trio"):
         anyio.run(greenback.with_portal_run_tree, anyio.sleep, 1, backend="asyncio")
 

--- a/newsfragments/12.bugfix.rst
+++ b/newsfragments/12.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`greenback.has_portal` now returns False instead of raising an
+error if called outside async context.

--- a/newsfragments/13.bugfix.rst
+++ b/newsfragments/13.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`greenback.has_portal` now properly respects its *task* argument;
+previously it erroneously would always inspect the current task.


### PR DESCRIPTION
`has_portal()` now returns False instead of raising an error if called outside async context (fixes #12) and respects the given *task* argument.