### PR TITLE
Add decorate_as_sync()

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch=True
 source=greenback
 concurrency=greenlet
 
+# When modifying exclude patterns, be sure to update .coveragercpypy as well
 [report]
 precision = 1
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,5 @@ precision = 1
 exclude_lines =
   pragma: no cover
   abc.abstractmethod
+  @overload
   if TYPE_CHECKING:

--- a/.coveragercpypy
+++ b/.coveragercpypy
@@ -9,4 +9,5 @@ precision = 1
 exclude_lines =
   pragma: no cover
   abc.abstractmethod
+  @overload
   if TYPE_CHECKING:

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -75,6 +75,9 @@ be helpful when adapting async code to work with synchronous interfaces.
 
    For example, this can be used for magic methods, property setters, and so on.
 
+.. autofunction:: decorate_as_sync(decorator)
+   :decorator:
+
 .. function:: async_context(async_cm)
    :with:
 

--- a/greenback/__init__.py
+++ b/greenback/__init__.py
@@ -10,4 +10,4 @@ from ._impl import (
     with_portal_run_tree,
     await_,
 )
-from ._util import autoawait, async_context, async_iter
+from ._util import autoawait, decorate_as_sync, async_context, async_iter

--- a/greenback/_tests/test_util.py
+++ b/greenback/_tests/test_util.py
@@ -1,6 +1,7 @@
 import functools
 import gc
 import pytest
+import sys
 import trio
 from async_generator import asynccontextmanager
 
@@ -35,7 +36,7 @@ def get_py_lru_cache():
         sys.modules["_functools"] = _functools
 
 
-@pytest.parameterize("lru_cache", (functools.lru_cache, get_py_lru_cache()))
+@pytest.mark.parametrize("lru_cache", (functools.lru_cache, get_py_lru_cache()))
 async def test_decorate_as_sync(lru_cache):
     @decorate_as_sync(functools.lru_cache())
     async def example(*args, **kw):

--- a/greenback/_tests/test_util.py
+++ b/greenback/_tests/test_util.py
@@ -22,22 +22,7 @@ async def test_autoawait():
     assert trio.current_time() == 6
 
 
-def get_py_lru_cache():
-    try:
-        _functools = sys.modules["_functools"]
-        functools = sys.modules.pop("functools")
-    except KeyError:
-        return functools.lru_cache
-    sys.modules["_functools"] = None
-    try:
-        return __import__("functools").lru_cache
-    finally:
-        sys.modules["functools"] = functools
-        sys.modules["_functools"] = _functools
-
-
-@pytest.mark.parametrize("lru_cache", (functools.lru_cache, get_py_lru_cache()))
-async def test_decorate_as_sync(lru_cache):
+async def test_decorate_as_sync():
     @decorate_as_sync(functools.lru_cache())
     async def example(*args, **kw):
         assert has_portal()

--- a/greenback/_tests/test_util.py
+++ b/greenback/_tests/test_util.py
@@ -1,10 +1,11 @@
+import functools
 import gc
 import pytest
 import trio
 from async_generator import asynccontextmanager
 
-from .._impl import ensure_portal
-from .._util import autoawait, async_context, async_iter
+from .._impl import ensure_portal, has_portal
+from .._util import autoawait, async_context, async_iter, decorate_as_sync
 
 
 @autoawait
@@ -18,6 +19,24 @@ async def test_autoawait():
     await trio.sleep(2)
     sync_sleep(3)
     assert trio.current_time() == 6
+
+
+async def test_decorate_as_sync():
+    @decorate_as_sync(functools.lru_cache())
+    async def example(*args, **kw):
+        assert has_portal()
+        await trio.sleep(1)
+        return (sum(args), list(kw.keys()))
+
+    assert example.__wrapped__.__name__ == "example"
+
+    assert (3, ["test"]) == await example(1, 2, test="foo")
+    assert trio.current_time() == 1
+    assert (3, ["test"]) == await example(1, 2, test="foo")
+    assert trio.current_time() == 1
+    assert (1, []) == await example(1)
+    assert trio.current_time() == 2
+    assert not has_portal()
 
 
 class AsyncMagic:

--- a/greenback/_util.py
+++ b/greenback/_util.py
@@ -45,9 +45,9 @@ def decorate_as_sync(decorator: Callable[[F], F]) -> Callable[[AF], AF]:
 # the decorated function are both async. (This could be improved using ParamSpec
 # for decorators that are args-preserving but not return-type-preserving.)
 @overload
-def decorate_as_sync(decorator: Callable[..., Any]) -> Callable[
-    [Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]
-]:
+def decorate_as_sync(
+    decorator: Callable[..., Any]
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
     ...
 
 
@@ -81,8 +81,9 @@ def decorate_as_sync(decorator: Any) -> Any:
         )
 
     """
+
     def decorate(async_fn: Any) -> Any:
-        @decorator
+        @decorator  # type: ignore  # "Untyped decorator makes 'inner' untyped"
         @wraps(async_fn)
         def inner(*args: Any, **kwds: Any) -> Any:
             return await_(async_fn(*args, **kwds))

--- a/newsfragments/14.feature.rst
+++ b/newsfragments/14.feature.rst
@@ -1,0 +1,3 @@
+Added `@greenback.decorate_as_sync() <greenback.decorate_as_sync>`, which wraps
+a synchronous function decorator such as :func:`functools.lru_cache` so that it
+can be used to decorate an async function.


### PR DESCRIPTION
This helper eases the application of a synchronous decorator (like functools.lru_cache) to an async function.