### PR TITLE
Fix contextvar leakage when one greenback-enabled task calls bestow_portal() for another

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
         arch: ['x86', 'x64']
         extra_name: ['']
         old_greenlet: ['0']
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['pypy-3.6', 'pypy-3.7', 'pypy-3.8', '3.6', '3.7', '3.8', '3.9', '3.10', '3.8-dev', '3.9-dev', '3.10-dev']
+        python: ['pypy-3.8', 'pypy-3.9', '3.7', '3.8', '3.9', '3.10', '3.11', '3.10-dev', '3.11-dev']
         check_lint: ['0']
         extra_name: ['']
         old_greenlet: ['0']
@@ -72,12 +72,9 @@ jobs:
           - python: '3.9'  # NB: old greenlet not supported on >=3.10
             old_greenlet: '1'
             extra_name: ', older greenlet package'
-          - python: '3.7'  # <- not actually used
-            pypy_nightly_branch: 'py3.7'
-            extra_name: ', pypy 3.7 nightly'
-          - python: '3.8'  # <- not actually used
-            pypy_nightly_branch: 'py3.8'
-            extra_name: ', pypy 3.8 nightly'
+          - python: '3.9'  # <- not actually used
+            pypy_nightly_branch: 'py3.9'
+            extra_name: ', pypy 3.9 nightly'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -107,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -52,8 +52,8 @@ aio_task_coro_c_offset: Optional[int] = None
 # greenlet v0.4.17 tried to be context-aware but isn't configurable
 # to get the behavior we want; we forbid it in our setup.py dependencies.)
 # See https://github.com/python-greenlet/greenlet/issues/196 for details.
-greenlet_needs_context_fixup: bool = (
-    contextvars is not None and getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
+greenlet_needs_context_fixup: bool = contextvars is not None and getattr(
+    greenlet, "GREENLET_USE_CONTEXT_VARS", False
 )
 
 
@@ -243,7 +243,7 @@ def current_task() -> Union["trio.lowlevel.Task", "asyncio.Task[Any]"]:
 
         if sys.version_info >= (3, 7):
             task = asyncio.current_task()
-        else:
+        else:  # pragma: no cover
             task = asyncio.Task.current_task()
         if task is None:  # pragma: no cover
             # typeshed says this is possible, but I haven't been able to induce it
@@ -311,13 +311,13 @@ def set_aio_task_coro(
     # ctypes.pythonapi.Py_{Inc,Dec}Ref because we might clash with user code
     # that also tries to use them but with different types. So private _ctypes
     # APIs it is!
-    import _ctypes  # type: ignore
+    import _ctypes
 
     coro_field = ctypes.c_size_t.from_address(id(task) + aio_task_coro_c_offset)
     assert coro_field.value == id(old_coro)
-    _ctypes.Py_INCREF(new_coro)
+    _ctypes.Py_INCREF(new_coro)  # type: ignore
     coro_field.value = id(new_coro)
-    _ctypes.Py_DECREF(old_coro)
+    _ctypes.Py_DECREF(old_coro)  # type: ignore
 
 
 def bestow_portal(task: Union["trio.lowlevel.Task", "asyncio.Task[Any]"]) -> None:

--- a/greenback/_impl.py
+++ b/greenback/_impl.py
@@ -88,7 +88,7 @@ def _greenback_shim(orig_coro: Coroutine[Any, Any, Any]) -> Generator[Any, Any, 
     # has a hard time raising StopIteration, because it's a generator,
     # and unrolling it into a non-generator iterable makes it slower.
     # So we'll accept a bit of code duplication.
-    parent_greenlet = greenlet.getcurrent()
+    parent_greenlet: greenlet.greenlet
 
     # The greenlet in which each send() or throw() call will occur.
     child_greenlet: Optional[greenlet.greenlet] = None
@@ -115,6 +115,11 @@ def _greenback_shim(orig_coro: Coroutine[Any, Any, Any]) -> Generator[Any, Any, 
             next_send = outcome.Error(ex)
         try:
             if not child_greenlet:
+                # It is important that we delay the parent_greenlet fetch until
+                # we actually create the child_greenlet. Otherwise, we will inherit
+                # whatever greenlet is active when bestow_portal() is called, which
+                # messes up the context fixup below.
+                parent_greenlet = greenlet.getcurrent()
                 # Start a new send() or throw() call on the original coroutine.
                 child_greenlet = greenlet.greenlet(next_send.send)
                 switch_arg: Any = orig_coro

--- a/greenback/_tests/test_impl.py
+++ b/greenback/_tests/test_impl.py
@@ -189,11 +189,6 @@ async def test_no_context_leakage():
 
 
 async def test_contextvars(library):
-    if sys.version_info < (3, 7) and library != "trio":
-        pytest.skip("contextvars not supported on this version")
-
-    import contextvars
-
     cv = contextvars.ContextVar("cv")
 
     async def inner():
@@ -206,9 +201,7 @@ async def test_contextvars(library):
         cv.set(20)
         await_(inner())
         assert cv.get() == 30
-        if sys.version_info >= (3, 7) and getattr(
-            greenlet, "GREENLET_USE_CONTEXT_VARS", False
-        ):
+        if getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False):
             # greenlet is not aware of the backported contextvars,
             # so can't support Context.run() correctly before 3.7.
             # greenlet that isn't contextvars-aware hangs if the

--- a/newsfragments/17.bugfix.rst
+++ b/newsfragments/17.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug that could result in inadvertent sharing of context variables. Specifically,
+when one task that already had a greenback portal set up called
+:func:`greenback.bestow_portal` on a different task, the second task could wind up
+sharing the first task's `contextvars` context.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,17 +3,12 @@ pytest
 pytest-cov
 pytest-trio
 
-# We run tests on both asyncio and Trio
-trio >= 0.16.0
-anyio >= 2.0
+# We run tests on both asyncio and Trio. anyio 4.0 (not yet released) and trio 0.22.0 must be used together.
+anyio < 4.0
+trio < 0.22.0
 
 # Tools
-black == 19.10b0; implementation_name == "cpython"
+black >= 19.10b0; implementation_name == "cpython"
 mypy >= 0.750; implementation_name == "cpython"
 flake8
 trio-typing >= 0.5.0
-
-# typed-ast is required by black + mypy and doesn't build on PyPy;
-# it will be unconstrained in requirements.txt if we don't
-# constrain it here
-typed-ast; implementation_name == "cpython"


### PR DESCRIPTION
Fixes #17. Verified that the new test fails without the code change here.