### PR TITLE
Fix: top-level imports not flagged as public for type checkers

### DIFF
--- a/greenback/__init__.py
+++ b/greenback/__init__.py
@@ -1,13 +1,19 @@
 """Top-level package for greenback."""
 
-from ._version import __version__
+# Redundant symbol imports flag as public for type checkers
+from ._version import __version__ as __version__
 from ._impl import (
-    ensure_portal,
-    bestow_portal,
-    has_portal,
-    with_portal_run,
-    with_portal_run_sync,
-    with_portal_run_tree,
-    await_,
+    ensure_portal as ensure_portal,
+    bestow_portal as bestow_portal,
+    has_portal as has_portal,
+    with_portal_run as with_portal_run,
+    with_portal_run_sync as with_portal_run_sync,
+    with_portal_run_tree as with_portal_run_tree,
+    await_ as await_,
 )
-from ._util import autoawait, decorate_as_sync, async_context, async_iter
+from ._util import (
+    autoawait as autoawait,
+    decorate_as_sync as decorate_as_sync,
+    async_context as async_context,
+    async_iter as async_iter,
+)


### PR DESCRIPTION
Pyright and Mypy both emit errors when using greenback's top-level symbols because they aren't recognized as public. Example pyright error:
`trio.py`:
```python
4: import greenback
...
22:         result = await greenback.with_portal_run_tree(async_fn, *args)
...
```
Error:
```
  .../trio.py:22:34 - error: "with_portal_run_tree" is not exported from module "greenback" (reportPrivateImportUsage)
```
This branch changes those top-level imports to the redundant `from X import A as A` form to [flag that the symbols are public](https://typing.readthedocs.io/en/latest/source/libraries.html#library-interface-public-and-private-symbols).